### PR TITLE
Suggestions for localSymlinkOnly branch

### DIFF
--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -130,19 +130,19 @@ def get_destination_project(src_dir, project=None):
     if project is not None:
         return project
     return _get_applet_spec(src_dir)['project']
-    
+
 def is_link_local(link_target):
     """
     :param link_target: The target of a symbolic link, as given by os.readlink()
-    :type link_target: string    
+    :type link_target: string
     :returns: A boolean indicating the link is local to the current directory.
               This is defined to mean that os.path.isabs(link_target) == False
-              and the link NEVER references the parent directory, so 
+              and the link NEVER references the parent directory, so
               "./foo/../../curdir/foo" would return False.
     :rtype: boolean
     """
     is_local=(not os.path.isabs(link_target))
-    
+
     if is_local:
         # make sure that the path NEVER extends outside the resources directory!
         d,l = os.path.split(link_target)
@@ -151,13 +151,13 @@ def is_link_local(link_target):
             link_parts.append(l)
             d,l = os.path.split(d)
         curr_path = os.sep
-    
+
         for p in reversed(link_parts):
             is_local = (is_local and not (curr_path == os.sep and p == os.pardir) )
             curr_path = os.path.abspath(os.path.join(curr_path, p))
-            
-    return is_local    
-    
+
+    return is_local
+
 def _fix_perms(perm_obj):
     """
     :param perm_obj: A permissions object, as given by os.stat()
@@ -172,9 +172,9 @@ def _fix_perms(perm_obj):
     ret_perm = perm_obj | stat.S_IROTH | stat.S_IRGRP | stat.S_IRUSR
     if ret_perm & stat.S_IXUSR:
         ret_perm = ret_perm | stat.S_IXGRP | stat.S_IXOTH
-    
+
     return ret_perm
-    
+
 def _fix_perm_filter(tar_obj):
     """
     :param tar_obj: A TarInfo object to be added to a tar file
@@ -183,7 +183,7 @@ def _fix_perm_filter(tar_obj):
     :rtype: tarfile.TarInfo
     """
     tar_obj.mode = _fix_perms(tar_obj.mode)
-    return tar_obj   
+    return tar_obj
 
 
 def upload_resources(src_dir, project=None, folder='/', ensure_upload=False, force_symlinks=False):
@@ -222,15 +222,14 @@ def upload_resources(src_dir, project=None, folder='/', ensure_upload=False, for
     if os.path.exists(resources_dir) and len(os.listdir(resources_dir)) > 0:
         target_folder = applet_spec['folder'] if 'folder' in applet_spec else folder
 
-        # While creating the resource bundle, optimistically look for a 
-        # resource bundle with the same contents, and reuse it if possible. 
-        # The resource bundle carries a property 'resource_bundle_checksum' 
-        # that indicates the checksum; the way in which the checksum is 
-        # computed is given below.   If the checksum matches  (and 
+        # While creating the resource bundle, optimistically look for a
+        # resource bundle with the same contents, and reuse it if possible.
+        # The resource bundle carries a property 'resource_bundle_checksum'
+        # that indicates the checksum; the way in which the checksum is
+        # computed is given below.   If the checksum matches  (and
         # ensure_upload is False), then we will use the existing file,
         # otherwise, we will compress and upload the tarball.
-        
-        
+
         # The input to the SHA1 contains entries of the form (whitespace
         # only included here for readability):
         #
@@ -242,187 +241,186 @@ def upload_resources(src_dir, project=None, folder='/', ensure_upload=False, for
         # specified below), followed by a numeric representation of the
         # mode, and the mtime in milliseconds since the epoch.
         #
-        # Note when looking at a link, unless --force-symlinks is specified, 
-        # and the link is to be dereferenced the mtime is taken to be the 
-        # maximum of the mtime of the link itself and of the link's target.  
-        # Additionally, the mode is the mode of the link's target.  
-        # If --force-symlinks is specified, or if the link is not to be 
+        # Note when looking at a link, unless --force-symlinks is specified,
+        # and the link is to be dereferenced the mtime is taken to be the
+        # maximum of the mtime of the link itself and of the link's target.
+        # Additionally, the mode is the mode of the link's target.
+        # If --force-symlinks is specified, or if the link is not to be
         # dereferenced, we'll only look at the link itself.
-        
+
         # get the absolute resource directory, and go there
         # this is the equivalent of "-C" in tar
         abs_resources_dir = os.path.abspath(resources_dir)
         old_curdir = os.getcwd()
         os.chdir(abs_resources_dir)
-        
-        
-        with tempfile.NamedTemporaryFile(suffix=".tar") as tar_tmp_fh:
-        
-            output_sha1 = hashlib.sha1()
-            tar_fh = tarfile.open(fileobj=tar_tmp_fh, mode='w')        
-        
-            for dirname, subdirs, files in os.walk(resources_dir):
-                if not dirname.startswith(resources_dir):
-                    raise AssertionError('Expected %r to start with root directory %r' % (dirname, resources_dir))
 
-                # Add an entry for the directory itself
-                relative_dirname = dirname[len(resources_dir):]
-                dir_stat = os.lstat(dirname)
-                if not relative_dirname.startswith('/'):
-                    relative_dirname = '/' + relative_dirname
+        try:
+            with tempfile.NamedTemporaryFile(suffix=".tar") as tar_tmp_fh:
+                output_sha1 = hashlib.sha1()
+                tar_fh = tarfile.open(fileobj=tar_tmp_fh, mode='w')
 
-                fields = [relative_dirname, str(_fix_perms(dir_stat.st_mode)), str(int(dir_stat.st_mtime * 1000))]
-                output_sha1.update(b''.join(s.encode('utf-8') + b'\0' for s in fields))
-                
-                # add an entry in the tar file for the current directory, but
-                # do not recurse!
-                tar_fh.add('.' + relative_dirname, recursive=False, filter=_fix_perm_filter)
-                
-                # Canonicalize the order of subdirectories; this is the order in
-                # which they will be visited by os.walk
-                subdirs.sort()
-                
-                # check the subdirectories for symlinks.  We should throw an error
-                # if there are any links that point outside of the directory (unless
-                # --force-symlinks is given).  If a link is pointing internal to 
-                # the directory (or --force-symlinks is given), we should add it 
-                # as a file.
-                for subdir_name in subdirs:
-                    dir_path = os.path.join(dirname, subdir_name)
+                for dirname, subdirs, files in os.walk(resources_dir):
+                    if not dirname.startswith(resources_dir):
+                        raise AssertionError('Expected %r to start with root directory %r' % (dirname, resources_dir))
 
-                    # If we do have a symlink,                     
-                    if os.path.islink(dir_path):
-                        # Let's get the pointed-to path to ensure that it is
-                        # still in the directory
-                        link_target = os.readlink(dir_path)
-                                                                       
-                        # If this is a local link, add it to the list of files (case 1)
-                        # else raise an error
-                        if force_symlinks or is_link_local(link_target):
-                            files.append(subdir_name)
-                        else:
-                            raise AppBuilderException("Cannot include symlinks to directories outside of the resource directory.  '%s' points to directory '%s'" % (dir_path, os.path.realpath(dir_path)))
-                        
+                    # Add an entry for the directory itself
+                    relative_dirname = dirname[len(resources_dir):]
+                    dir_stat = os.lstat(dirname)
+                    if not relative_dirname.startswith('/'):
+                        relative_dirname = '/' + relative_dirname
 
-                # Canonicalize the order of files so that we compute the
-                # checksum in a consistent order
-                for filename in sorted(files):
-                    deref_link = False
-                
-                    relative_filename = os.path.join(relative_dirname, filename)
-                    true_filename = os.path.join(dirname, filename)
-
-                    file_stat = os.lstat(true_filename)
-                    # check for a link here, please!
-                    if os.path.islink(true_filename):
-
-                        # Get the pointed-to path
-                        link_target = os.readlink(true_filename)
-
-                        if not (force_symlinks or is_link_local(link_target)):
-                            # if we are pointing outside of the directory, then:
-                            # try to get the true stat of the file and make sure
-                            # to dereference the link!
-                            try:
-                                file_stat = os.stat(os.path.join(dirname, link_target))
-                                deref_link = True
-                            except OSError:
-                                # uh-oh! looks like we have a broken link!
-                                # since this is guaranteed to cause problems (and
-                                # we know we're not forcing symlinks here), we
-                                # should throw an error
-                                raise AppBuilderException("Broken symlink: Link '%s' points to '%s', which does not exist" % (true_filename, os.path.realpath(true_filename)) )
-                    
-                    
-                    fields = [relative_filename, str(_fix_perms(file_stat.st_mode)), str(int(file_stat.st_mtime * 1000))]
+                    fields = [relative_dirname, str(_fix_perms(dir_stat.st_mode)), str(int(dir_stat.st_mtime * 1000))]
                     output_sha1.update(b''.join(s.encode('utf-8') + b'\0' for s in fields))
-                    
-                    # If we are to dereference, use the target fn
-                    if deref_link:
-                        true_filename = os.path.realpath(true_filename)
-                      
-                    tar_fh.add(true_filename, arcname='.' + relative_filename, filter=_fix_perm_filter)
-                    
-                # end for filename in sorted(files)
 
-            # end for dirname, subdirs, files in os.walk(resources_dir):
-        
-            # at this point, the tar is complete, so close the tar_fh
-            tar_fh.close()
-        
-            # Optimistically look for a resource bundle with the same
-            # contents, and reuse it if possible. The resource bundle
-            # carries a property 'resource_bundle_checksum' that indicates
-            # the checksum; the way in which the checksum is computed is
-            # given in the documentation of _directory_checksum.
+                    # add an entry in the tar file for the current directory, but
+                    # do not recurse!
+                    tar_fh.add('.' + relative_dirname, recursive=False, filter=_fix_perm_filter)
 
-            if ensure_upload:
-                properties_dict = {}
-                existing_resources = False
-            else:
-                directory_checksum = output_sha1.hexdigest()
-                properties_dict = dict(resource_bundle_checksum=directory_checksum)
-                existing_resources = dxpy.find_one_data_object(
-                    project=dest_project,
-                    folder=target_folder,
-                    properties=dict(resource_bundle_checksum=directory_checksum),
-                    visibility='either',
-                    zero_ok=True,
-                    state='closed',
-                    return_handler=True
-                )
+                    # Canonicalize the order of subdirectories; this is the order in
+                    # which they will be visited by os.walk
+                    subdirs.sort()
 
-            if existing_resources:
-                logger.info("Found existing resource bundle that matches local resources directory: " +
-                            existing_resources.get_id())
+                    # check the subdirectories for symlinks.  We should throw an error
+                    # if there are any links that point outside of the directory (unless
+                    # --force-symlinks is given).  If a link is pointing internal to
+                    # the directory (or --force-symlinks is given), we should add it
+                    # as a file.
+                    for subdir_name in subdirs:
+                        dir_path = os.path.join(dirname, subdir_name)
 
-                dx_resource_archive = existing_resources
-            else:
-            
-                logger.debug("Uploading in " + src_dir)
-                # We need to compress the tar that we've created
-                
-                
-                targz_fh = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
-                
-                # compress the file by reading the tar file and passing
-                # it though a GzipFile object, writing the given 
-                # block size (by default 8192 bytes) at a time
-                targz_gzf = gzip.GzipFile(fileobj=targz_fh)
-                tar_tmp_fh.seek(0)
-                dat = tar_tmp_fh.read(io.DEFAULT_BUFFER_SIZE)
-                while dat:
-                    targz_gzf.write(dat)
+                        # If we do have a symlink,
+                        if os.path.islink(dir_path):
+                            # Let's get the pointed-to path to ensure that it is
+                            # still in the directory
+                            link_target = os.readlink(dir_path)
+
+                            # If this is a local link, add it to the list of files (case 1)
+                            # else raise an error
+                            if force_symlinks or is_link_local(link_target):
+                                files.append(subdir_name)
+                            else:
+                                raise AppBuilderException("Cannot include symlinks to directories outside of the resource directory.  '%s' points to directory '%s'" % (dir_path, os.path.realpath(dir_path)))
+
+                    # Canonicalize the order of files so that we compute the
+                    # checksum in a consistent order
+                    for filename in sorted(files):
+                        deref_link = False
+
+                        relative_filename = os.path.join(relative_dirname, filename)
+                        true_filename = os.path.join(dirname, filename)
+
+                        file_stat = os.lstat(true_filename)
+                        # check for a link here, please!
+                        if os.path.islink(true_filename):
+
+                            # Get the pointed-to path
+                            link_target = os.readlink(true_filename)
+
+                            if not (force_symlinks or is_link_local(link_target)):
+                                # if we are pointing outside of the directory, then:
+                                # try to get the true stat of the file and make sure
+                                # to dereference the link!
+                                try:
+                                    file_stat = os.stat(os.path.join(dirname, link_target))
+                                    deref_link = True
+                                except OSError:
+                                    # uh-oh! looks like we have a broken link!
+                                    # since this is guaranteed to cause problems (and
+                                    # we know we're not forcing symlinks here), we
+                                    # should throw an error
+                                    raise AppBuilderException("Broken symlink: Link '%s' points to '%s', which does not exist" % (true_filename, os.path.realpath(true_filename)) )
+
+                        fields = [relative_filename, str(_fix_perms(file_stat.st_mode)), str(int(file_stat.st_mtime * 1000))]
+                        output_sha1.update(b''.join(s.encode('utf-8') + b'\0' for s in fields))
+
+                        # If we are to dereference, use the target fn
+                        if deref_link:
+                            true_filename = os.path.realpath(true_filename)
+
+                        tar_fh.add(true_filename, arcname='.' + relative_filename, filter=_fix_perm_filter)
+
+                    # end for filename in sorted(files)
+
+                # end for dirname, subdirs, files in os.walk(resources_dir):
+
+                # at this point, the tar is complete, so close the tar_fh
+                tar_fh.close()
+
+                # Optimistically look for a resource bundle with the same
+                # contents, and reuse it if possible. The resource bundle
+                # carries a property 'resource_bundle_checksum' that indicates
+                # the checksum; the way in which the checksum is computed is
+                # given in the documentation of _directory_checksum.
+
+                if ensure_upload:
+                    properties_dict = {}
+                    existing_resources = False
+                else:
+                    directory_checksum = output_sha1.hexdigest()
+                    properties_dict = dict(resource_bundle_checksum=directory_checksum)
+                    existing_resources = dxpy.find_one_data_object(
+                        project=dest_project,
+                        folder=target_folder,
+                        properties=dict(resource_bundle_checksum=directory_checksum),
+                        visibility='either',
+                        zero_ok=True,
+                        state='closed',
+                        return_handler=True
+                    )
+
+                if existing_resources:
+                    logger.info("Found existing resource bundle that matches local resources directory: " +
+                                existing_resources.get_id())
+
+                    dx_resource_archive = existing_resources
+                else:
+
+                    logger.debug("Uploading in " + src_dir)
+                    # We need to compress the tar that we've created
+
+
+                    targz_fh = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
+
+                    # compress the file by reading the tar file and passing
+                    # it though a GzipFile object, writing the given
+                    # block size (by default 8192 bytes) at a time
+                    targz_gzf = gzip.GzipFile(fileobj=targz_fh)
+                    tar_tmp_fh.seek(0)
                     dat = tar_tmp_fh.read(io.DEFAULT_BUFFER_SIZE)
-                
-                targz_gzf.flush()
-                targz_gzf.close()
-                targz_fh.close()
-                    
-                if 'folder' in applet_spec:
-                    try:
-                        dxpy.get_handler(dest_project).new_folder(applet_spec['folder'], parents=True)
-                    except dxpy.exceptions.DXAPIError:
-                        pass # TODO: make this better
-                    
-                dx_resource_archive = dxpy.upload_local_file(
-                    targz_fh.name,
-                    wait_on_close=True,
-                    project=dest_project,
-                    folder=target_folder,
-                    hidden=True,
-                    properties=properties_dict
-                )
-                
-                os.unlink(targz_fh.name)
-                    
-                # end compressed file creation and upload
+                    while dat:
+                        targz_gzf.write(dat)
+                        dat = tar_tmp_fh.read(io.DEFAULT_BUFFER_SIZE)
 
-            archive_link = dxpy.dxlink(dx_resource_archive.get_id())
-                
-        # end tempfile.NamedTemporaryFile(suffix=".tar") as tar_fh
-        
-        return [{'name': 'resources.tar.gz', 'id': archive_link}]
+                    targz_gzf.flush()
+                    targz_gzf.close()
+                    targz_fh.close()
+
+                    if 'folder' in applet_spec:
+                        try:
+                            dxpy.get_handler(dest_project).new_folder(applet_spec['folder'], parents=True)
+                        except dxpy.exceptions.DXAPIError:
+                            pass # TODO: make this better
+
+                    dx_resource_archive = dxpy.upload_local_file(
+                        targz_fh.name,
+                        wait_on_close=True,
+                        project=dest_project,
+                        folder=target_folder,
+                        hidden=True,
+                        properties=properties_dict
+                    )
+
+                    os.unlink(targz_fh.name)
+
+                    # end compressed file creation and upload
+
+                archive_link = dxpy.dxlink(dx_resource_archive.get_id())
+
+            # end tempfile.NamedTemporaryFile(suffix=".tar") as tar_fh
+
+            return [{'name': 'resources.tar.gz', 'id': archive_link}]
+        finally:
+            os.chdir(old_curdir)
     else:
         return []
 

--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -36,9 +36,13 @@ the effective destination project.
 
 from __future__ import print_function, unicode_literals, division, absolute_import
 
-import os, sys, json, subprocess, tempfile, multiprocessing, gzip, io, tarfile, stat
+import os, sys, json, subprocess, tempfile, multiprocessing
 import datetime
+import gzip
 import hashlib
+import io
+import stat
+import tarfile
 
 import dxpy
 from . import logger

--- a/src/python/dxpy/app_builder.py
+++ b/src/python/dxpy/app_builder.py
@@ -242,11 +242,9 @@ def upload_resources(src_dir, project=None, folder='/', ensure_upload=False, for
         # mode, and the mtime in milliseconds since the epoch.
         #
         # Note when looking at a link, unless --force-symlinks is specified,
-        # and the link is to be dereferenced the mtime is taken to be the
-        # maximum of the mtime of the link itself and of the link's target.
-        # Additionally, the mode is the mode of the link's target.
-        # If --force-symlinks is specified, or if the link is not to be
-        # dereferenced, we'll only look at the link itself.
+        # the link will be dereferenced, and the mtime and mode are those of
+        # the link's target. If --force-symlinks is specified, or if the link
+        # is not to be dereferenced, we'll only look at the link itself.
 
         # get the absolute resource directory, and go there
         # this is the equivalent of "-C" in tar

--- a/src/python/dxpy/scripts/dx_build_app.py
+++ b/src/python/dxpy/scripts/dx_build_app.py
@@ -63,7 +63,7 @@ parser.add_argument("--force-symlinks", help="If specified, will not attempt to 
                                             "outside the resource directory are dereferenced (note "+
                                             "that links to directories outside of the resource directory " +
                                             "will cause an error).",
-                    action="store_true")                    
+                    action="store_true")
 
 src_dir_action = parser.add_argument("src_dir", help="App or applet source directory (default: current directory)", nargs='?')
 src_dir_action.completer = LocalCompleter()

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -19,8 +19,10 @@
 
 from __future__ import print_function, unicode_literals, division, absolute_import
 
-import os, sys, unittest, json, tempfile, subprocess, csv, shutil, re, base64, random, time, filecmp, stat
+import os, sys, unittest, json, tempfile, subprocess, csv, shutil, re, base64, random, time
+import filecmp
 import pipes
+import stat
 import hashlib
 import collections
 from contextlib import contextmanager

--- a/src/python/test/test_dxclient.py
+++ b/src/python/test/test_dxclient.py
@@ -6213,11 +6213,11 @@ def main(in1):
     def _build_check_resources(self, app_dir, args="", extract_resources=True):
         """
         Builds an app given the arguments and either:
-            - downloads and extracts the tarball to a temp directory, returning the path of 
+            - downloads and extracts the tarball to a temp directory, returning the path of
               the temp directory (when extract_resources is True), or
             - returns the ID of the resource bundle (when extract_resources is False)
         """
-        
+
         # create applet and get the resource_file id
         new_applet = json.loads(run("dx build -f --json " + args + " " + app_dir))
         applet_describe = dxpy.api.applet_describe(new_applet["id"])
@@ -6226,7 +6226,7 @@ def main(in1):
 
         if not extract_resources:
             return id1
-        
+
         # download resources tar and extract it to a temp. directory.
         # note that if the resource directory also contains a file of the name
         # './res.tar.gz', things could get ugly, but this is just a helper for
@@ -6236,7 +6236,7 @@ def main(in1):
         subprocess.check_call(['tar', '-zxf', os.path.join(res_temp_dir, 'res.tar.gz'), '-C', res_temp_dir])
 
         # remove the original tar file
-        os.remove(os.path.join(res_temp_dir, 'res.tar.gz'))        
+        os.remove(os.path.join(res_temp_dir, 'res.tar.gz'))
 
         # return the temp directory to perform tests specific to the configuration
         return res_temp_dir
@@ -6257,53 +6257,53 @@ def main(in1):
 
         with open(os.path.join(app_dir, 'resources', 'test_file2.txt'), 'w') as resources_file2:
             resources_file2.write('test_file2\n')
-            
+
         if 'symbolic_link' in os.listdir(os.path.join(app_dir, 'resources')):
             os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
 
         # ==== Case 1 ====
-        
+
         # == Links to local files are kept
         os.symlink(os.path.join(os.curdir, 'test_file2.txt'), os.path.join(app_dir, 'resources', 'symbolic_link'))
 
         # build app
         res_temp_dir = self._build_check_resources(app_dir)
         # Test symbolic_link is soft link
-        self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))     
+        self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
 
         shutil.rmtree(res_temp_dir)
-        
+
         # == Links to local directories are kept when using relative build directory
-        
+
         curdir = os.getcwd()
         os.chdir(os.path.join(app_dir, os.pardir))
 
         # NOTE: As of master on 4/27, "dx build ." fails not related to the resource build.
-        # To re-enable this test when that issue is resolved, remove all "#REM-" from this file  
+        # To re-enable this test when that issue is resolved, remove all "#REM-" from this file
 
         # build app in the current wd
         #REM-res_temp_dir = self._build_check_resources('app')
-        
+
         # Test symbolic_link is a soft link
-        #REM-self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))     
+        #REM-self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
 
         #REM-shutil.rmtree(res_temp_dir)
         os.chdir(curdir)
-        
+
         # == Links to local directories are kept
         os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
         os.mkdir(os.path.join(app_dir, 'resources', 'local_dir'))
         os.symlink(os.path.join(os.curdir, 'local_dir'), os.path.join(app_dir, 'resources', 'symbolic_link'))
-        
+
         # build app
         res_temp_dir = self._build_check_resources(app_dir)
         # Test symbolic_link is soft link
-        self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))     
+        self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
 
         shutil.rmtree(res_temp_dir)
 
         # ==== Case 2 ====
-        
+
         # == Links to remote files are dereferenced
         with open(os.path.join(app_dir, os.pardir, 'test_file_outside.txt'), 'w') as file1:
             file1.write('test_file_outside\n')
@@ -6313,28 +6313,28 @@ def main(in1):
 
         # create applet and get the resource_file id
         res_temp_dir = self._build_check_resources(app_dir)
-        
+
         # Test: symbolic_link exists, is NOT a link, and has the same content
         #       as app_dir/test_file_outside.txt
         self.assertTrue(os.path.exists(os.path.join(res_temp_dir, 'symbolic_link')))
         self.assertFalse(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
         self.assertTrue(filecmp.cmp(os.path.join(res_temp_dir, 'symbolic_link'),
                                     os.path.join(app_dir, os.pardir, 'test_file_outside.txt')))
-        
+
         shutil.rmtree(res_temp_dir)
-        
+
         # == Links to remote files are NOT dereferenced with --force-symlink
 
         # create applet and get the resource_file id
         res_temp_dir = self._build_check_resources(app_dir, "--force-symlinks")
-        
+
         # Test: symbolic_link is a symlink
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
-        
+
         shutil.rmtree(res_temp_dir)
-        
+
         # ==== Case 3 ====
-        
+
         # == Broken remote links result in build error
         # NOTE: we just removed the test_file_outside.txt, breaking symbolic_link
         os.remove(os.path.join(app_dir, os.pardir, 'test_file_outside.txt'))
@@ -6343,57 +6343,57 @@ def main(in1):
             run("dx build -f " + app_dir)
 
         # == Broken remote links are NOT dereferenced with --force-symlink
-        
+
         # create applet and get the resource_file id
         res_temp_dir = self._build_check_resources(app_dir, "--force-symlinks")
-        
+
         # Test: symbolic_link is a symlink
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
-        
+
         shutil.rmtree(res_temp_dir)
 
         # ==== Case 4 ====
-        
+
         # == Links to remote directories causes an AssertionError
         os.mkdir(os.path.join(app_dir, 'test_outside_dir'))
         os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
         os.symlink(os.path.join(os.pardir, 'test_outside_dir'),
                    os.path.join(app_dir, 'resources', 'symbolic_link'))
-                   
+
         with self.assertSubprocessFailure(stderr_regexp="Cannot include symlinks to directories outside of the resource directory"):
             run("dx build -f " + app_dir)
-        
+
         # == Links to remote directories are NOT dereferenced with --force-symlink
-        
+
         # create applet and get the resource_file id
         res_temp_dir = self._build_check_resources(app_dir, "--force-symlinks")
-        
+
         # Test: symbolic_link is a symlink
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
-        
+
         shutil.rmtree(res_temp_dir)
 
         # ==== Case 5 ====
-        
+
         # == Links to local links (regardless of eventual destination) are kept
         os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
-        
+
         with open(os.path.join(app_dir, os.pardir, 'remote_file'), 'w') as file1:
             file1.write('remote file outside\n')
-        
+
         os.symlink(os.path.join(os.pardir, os.pardir, 'remote_file'), os.path.join(app_dir, 'resources', 'remote_link'))
         os.symlink(os.path.join(os.curdir, 'remote_link'), os.path.join(app_dir, 'resources', 'symbolic_link'))
 
         # create applet and get the resource_file id
         res_temp_dir = self._build_check_resources(app_dir)
-        
+
         # Test: symbolic_link is a symlink
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
-        
+
         shutil.rmtree(res_temp_dir)
-        
+
         # ==== Case 6 ====
-        
+
         # == Links to remote links (which are links to a file) are dereferenced
         os.remove(os.path.join(app_dir, 'resources', 'remote_link'))
         os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
@@ -6409,70 +6409,70 @@ def main(in1):
         self.assertFalse(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
         self.assertTrue(filecmp.cmp(os.path.join(res_temp_dir, 'symbolic_link'),
                                     os.path.join(app_dir, os.pardir, 'lib', 'remote_file')))
-        
-        shutil.rmtree(res_temp_dir)   
-        
+
+        shutil.rmtree(res_temp_dir)
+
         # == Links to remote links (which are links to a file) are kept using --force-symlink
         res_temp_dir = self._build_check_resources(app_dir, "--force-symlinks")
-        
+
         # Test: symbolic_link is a symlink
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
 
         shutil.rmtree(res_temp_dir)
-                               
+
         # ==== Case 7 ====
-        
+
         # == Absolute links to files are ALWAYS dereferenced, regardless of destination
         os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
         os.symlink(os.path.join(app_dir, 'resources', 'test_file2.txt'), os.path.join(app_dir, 'resources', 'symbolic_link'))
 
         # create applet and get the resource_file id
         res_temp_dir = self._build_check_resources(app_dir)
-        
+
         # Test: symbolic_link is NOT a symlink and is the same file as test_file2.txt
         self.assertFalse(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
         self.assertTrue(filecmp.cmp(os.path.join(res_temp_dir, 'symbolic_link'),
                                     os.path.join(app_dir, 'resources', 'test_file2.txt')))
-        
+
         shutil.rmtree(res_temp_dir)
-        
+
         # == Absolute links to files are kept using --force-symlink
         res_temp_dir = self._build_check_resources(app_dir, "--force-symlinks")
-        
+
         # Test: symbolic_link is a symlink
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
 
         shutil.rmtree(res_temp_dir)
-              
+
         # == Absolute links to directories cause an error, regardless of destination
         os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
         os.symlink(os.path.join(app_dir, 'resources', 'local_dir'), os.path.join(app_dir, 'resources', 'symbolic_link'))
-        
+
         with self.assertSubprocessFailure(stderr_regexp="Cannot include symlinks to directories outside of the resource directory"):
             run("dx build -f " + app_dir)
-        
+
         # == Absolute links to directories are keps when --force-symlinks is used
         res_temp_dir = self._build_check_resources(app_dir, "--force-symlinks")
-        
+
         # Test: symbolic_link is a symlink
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
 
         # ==== Case 8 ====
-        
+
         # == Relative link to a file that extends outside the resource path is dereferenced
         os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
         os.symlink(os.path.join(os.pardir, 'resources', 'test_file2.txt'), os.path.join(app_dir, 'resources', 'symbolic_link'))
-        
+
         # create applet and get the resource_file id
         res_temp_dir = self._build_check_resources(app_dir)
-        
+
         # Test: symbolic_link is NOT a symlink and is the same file as test_file2.txt
         self.assertFalse(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
         self.assertTrue(filecmp.cmp(os.path.join(res_temp_dir, 'symbolic_link'),
                                     os.path.join(app_dir, 'resources', 'test_file2.txt')))
-                                    
+
         shutil.rmtree(res_temp_dir)
-                                    
+
         # == Relative link to a file that extends outside resource path is kept using --force-symlinks
         res_temp_dir = self._build_check_resources(app_dir, "--force-symlinks")
 
@@ -6480,22 +6480,22 @@ def main(in1):
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
 
         shutil.rmtree(res_temp_dir)
-        
+
         # == Relative link to directory extending outside resource path causes error
         os.remove(os.path.join(app_dir, 'resources', 'symbolic_link'))
         os.symlink(os.path.join(os.pardir, 'resources', 'local_dir'), os.path.join(app_dir, 'resources', 'symbolic_link'))
 
         with self.assertSubprocessFailure(stderr_regexp="Cannot include symlinks to directories outside of the resource directory"):
             run("dx build -f " + app_dir)
-        
+
         # == Relative link to directory extending outside resource path are kept when --force-symlinks is used
         res_temp_dir = self._build_check_resources(app_dir, "--force-symlinks")
-        
+
         # Test: symbolic_link is a symlink
         self.assertTrue(os.path.islink(os.path.join(res_temp_dir, 'symbolic_link')))
-        
+
         shutil.rmtree(res_temp_dir)
-        
+
     def test_upload_resources_permissions(self):
         app_spec = {
             "name": "upload_resources_permissions",
@@ -6522,24 +6522,24 @@ def main(in1):
             rf.write('test_permissions: 770\n')
         with open(os.path.join(app_dir, 'resources', 'test_670.txt'), 'w') as rf:
             rf.write('test_permissions: 670\n')
-        
+
         # Now, set the permissions alluded to above
-        os.chmod(os.path.join(app_dir, 'resources', 'test_644.txt'), 
+        os.chmod(os.path.join(app_dir, 'resources', 'test_644.txt'),
             stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-        os.chmod(os.path.join(app_dir, 'resources', 'test_660.txt'), 
+        os.chmod(os.path.join(app_dir, 'resources', 'test_660.txt'),
             stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP)
-        os.chmod(os.path.join(app_dir, 'resources', 'test_400.txt'), 
+        os.chmod(os.path.join(app_dir, 'resources', 'test_400.txt'),
             stat.S_IRUSR)
-        os.chmod(os.path.join(app_dir, 'resources', 'test_755.txt'), 
+        os.chmod(os.path.join(app_dir, 'resources', 'test_755.txt'),
             stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
-        os.chmod(os.path.join(app_dir, 'resources', 'test_770.txt'), 
+        os.chmod(os.path.join(app_dir, 'resources', 'test_770.txt'),
             stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP)
-        os.chmod(os.path.join(app_dir, 'resources', 'test_670.txt'), 
+        os.chmod(os.path.join(app_dir, 'resources', 'test_670.txt'),
             stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP)
-        
+
         # build app
         res_temp_dir = self._build_check_resources(app_dir)
-        
+
         # Test file permissions (all will have stat.S_IFREG as well)
         # 644 => 644
         self.assertEquals(os.stat(os.path.join(res_temp_dir, "test_644.txt")).st_mode,
@@ -6559,31 +6559,31 @@ def main(in1):
         # 670 => 674
         self.assertEquals(os.stat(os.path.join(res_temp_dir, "test_670.txt")).st_mode,
             stat.S_IFREG | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP | stat.S_IROTH)
-        
-        shutil.rmtree(res_temp_dir)                                     
-            
+
+        shutil.rmtree(res_temp_dir)
+
         # If we make a permission change that does NOT affect the tar, we should re-use the resource bundle
         id1 = self._build_check_resources(app_dir, extract_resources=False)
-        
+
         # change the 400 => 444
-        os.chmod(os.path.join(app_dir, 'resources', 'test_400.txt'), 
+        os.chmod(os.path.join(app_dir, 'resources', 'test_400.txt'),
             stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-        
+
         id2 = self._build_check_resources(app_dir, extract_resources=False)
-        
+
         self.assertEquals(id1, id2)
-        
+
         # If we make a permission change that DOES affect the tar, we should rebuild
-        
+
         # change 400 => 500 (will result in perms 555)
-        os.chmod(os.path.join(app_dir, 'resources', 'test_400.txt'), 
+        os.chmod(os.path.join(app_dir, 'resources', 'test_400.txt'),
             stat.S_IRUSR | stat.S_IXUSR)
-        
+
         id3 = self._build_check_resources(app_dir, extract_resources=False)
-        
+
         self.assertNotEquals(id1, id3)
-        
-        
+
+
     def test_upload_resources_advanced(self):
         app_spec = {
             "name": "upload_resources_advanced",
@@ -6628,30 +6628,30 @@ def main(in1):
         id4 = self._build_check_resources(app_dir, "--force-symlinks --ensure-upload", False)
 
         self.assertNotEqual(id3, id4)  # Upload should have happened
-        
-        # Also, the new bundle should not have a checksum property 
+
+        # Also, the new bundle should not have a checksum property
         # (and thus be eligible for future loads)
         resources_file_describe = json.loads(run("dx describe --json " + id4))
         self.assertNotIn('resource_bundle_checksum', resources_file_describe['properties'])
 
         # Test the behavior without --force-symlinks
-        
+
         # First, let's clean up the old resources directory
         shutil.rmtree(os.path.join(app_dir, 'resources'))
         os.mkdir(os.path.join(app_dir, 'resources'))
-        
+
         # create a couple files both inside and outside the directory
         with open(os.path.join(app_dir, 'outside_file1.txt'), 'w') as fn:
-            fn.write('test_file1\n')  
+            fn.write('test_file1\n')
         with open(os.path.join(app_dir, 'outside_file2.txt'), 'w') as fn:
             fn.write('test_file2\n')
         with open(os.path.join(app_dir, 'resources', 'inside_file1.txt'), 'w') as fn:
-            fn.write('test_file1\n')  
+            fn.write('test_file1\n')
         with open(os.path.join(app_dir, 'resources', 'inside_file2.txt'), 'w') as fn:
             fn.write('test_file2\n')
-            
+
         os.symlink(os.path.join(app_dir, 'outside_file1.txt'), os.path.join(app_dir, 'outside_link'))
-            
+
         # First, testing dereferencing of links
         # Create a link to be dereferenced
         if 'symbolic_link' in os.listdir(os.path.join(app_dir, 'resources')):
@@ -6661,44 +6661,44 @@ def main(in1):
         os.symlink(os.path.join(app_dir, 'outside_link'), os.path.join(app_dir, 'resources', 'symbolic_link'))
 
         idr1 = self._build_check_resources(app_dir, "", False)
-        
+
         # Update the link target; modify target mtime
         with open(os.path.join(app_dir, 'outside_file1.txt'), 'w') as fn:
             fn.write('test_file1 Update!\n')
-                    
+
         idr2 = self._build_check_resources(app_dir, "", False)
-        
+
         self.assertNotEqual(idr1, idr2) # Upload should happen
-        
+
         # Change link destination; target mtime change
         os.remove(os.path.join(app_dir, 'outside_link'))
         os.symlink(os.path.join(app_dir, 'outside_file2.txt'), os.path.join(app_dir, 'outside_link'))
 
         idr3 = self._build_check_resources(app_dir, "", False)
-        
+
         # New Upload should happen
         self.assertNotEqual(idr2, idr3)
-  
+
         # Add another link the the chain, but eventual destination doesn't change
         os.remove(os.path.join(app_dir, 'outside_link'))
         os.symlink(os.path.join(app_dir, 'outside_file2.txt'), os.path.join(app_dir, 'outside_link_1'))
         os.symlink(os.path.join(app_dir, 'outside_link_1'), os.path.join(app_dir, 'outside_link'))
 
         idr4 = self._build_check_resources(app_dir, "", False)
-        
+
         # New Upload should NOT happen - filename change
-        self.assertEqual(idr3, idr4) 
-        
+        self.assertEqual(idr3, idr4)
+
         # However, if we ensure upload, we need to upload!
         idr5 = self._build_check_resources(app_dir, "--ensure-upload", False)
-        
+
         # New Upload should happen
         self.assertNotEqual(idr4, idr5)
 
         # NOTE: for non-dereferenced links, almost any change will result in an mtime change
         # for the directory or a file within.  It's virtually impossible to make a local
         # symlink change and NOT create a new tarball, so we won't test that
-        
+
     def test_archive_in_another_project(self):
         app_spec = {
             "name": "archive_in_another_project",


### PR DESCRIPTION
Hi John,

I made these changes while testing out your branch locally. Please have a look and merge this into your branch if you think they make sense.
- Removed trailing whitespace at the end of all lines and add newly introduced imports on their own line (per PEP8)
- I believe that "dx build ." (and probably "dx build" on other relative paths too) was failing because the working directory was set in preparation for the tar file to be created. I fixed "dx build ." by restoring the original cwd after the tar file is complete. Can you confirm whether this fixes the problem you observed as well, or can you give me more info about how to reproduce the problem you're seeing on master? (I then tried to uncomment out the tests that you had disabled in connection with this issue, but they still failed.)
- I removed a comment about using the maximum of the mtimes of the symlink and its referent (which I am guessing is a comment you added but never implemented).

Thanks,
Phil
